### PR TITLE
A few updates to SublimeTextSwiftAutocomplete

### DIFF
--- a/src/source_kitten.py
+++ b/src/source_kitten.py
@@ -170,8 +170,11 @@ def _calculate_offset_in_bytes(length_offset, text):
 
 def _create_temp_file(text):
     path = temp_file_path()
-    with open(path, "w") as text_file:
-        text_file.write(text)
+
+    # To avoid ascii-conversion issues, we encode the file as a binary file containing utf-8 encoded text
+    with open(path, "wb") as text_file:
+        binData = bytes(text, encoding='utf-8', errors='ignore')
+        text_file.write(binData)
     return path
 
 def _remove_temp_file():

--- a/src/sourcekit_xml_to_html.py
+++ b/src/sourcekit_xml_to_html.py
@@ -9,13 +9,13 @@ from xml.etree import ElementTree
 xml_to_html_tags = {
     "Name"              : "strong",   "Abstract"          : "div",
     "Protocol"          : "div",      "InstanceMethod"    : "div",
-    "SeeAlsos"          : "div",      "Discussion"        : "span",
+    "SeeAlsos"          : "div",      "Discussion"        : "div",
     "Declaration"       : "div",      "Class"             : "div",
     "Note"              : "div",      "Para"              : "p",
     "SeeAlso"           : "p",        "Availability"      : "p",
     "zModuleImport"     : "p",        "zAttributes"       : "p",
     "Attribute"         : "p",        "uAPI"              : "a",
-    "codeVoice"         : "span",      "newTerm"           : "em",
+    "codeVoice"         : "span",     "newTerm"           : "em",
     "List-Bullet"       : "ul",       "Item"              : "li",
     "AvailabilityItem"  : "em",       "InstanceProperty"  : "div",
     "CodeListing"       : "div",      "reservedWord"      : "b",
@@ -26,7 +26,8 @@ xml_to_html_tags = {
     "Constant"          : "div",      "Parameter"         : "li",
     "Parameters"        : "ul",       "CodeListing"       : "div",
     "zCodeLineNumbered" : "span",     "emphasis"          : "em",
-    "Complexity"        : "div",      "USR"               : "span"
+    "Complexity"        : "div",      "USR"               : "span",
+    "Type"              : "span"
 }
 
 css = """
@@ -48,22 +49,43 @@ ul {
 }
 
 .zcodelinenumbered {
+    font-family: monospace;
     display: block;
 }
 
 .codelisting {
+    font-family: monospace;
     padding: 0.5rem;
     background-color: color(var(--background) blend(var(--foreground) 85%));
 }
 
 .codevoice {
+    font-family: monospace;
     background-color: color(var(--background) blend(var(--foreground) 85%));
 }
 
-.discussion, li p {
+.type {
+    background-color: color(var(--background) blend(var(--foreground) 85%));
+}
+
+.li p {
     padding: 0;
     margin: 0;
     display: inline;
+}
+
+.abstract {
+    color: #E4DCC7;
+    padding-top: -1rem;
+    margin: 0;
+    display: block;
+}
+
+.discussion {
+    color: #C5BEAB;
+    padding-top: -1rem;
+    margin: 0;
+    display: block;
 }
 </style>
 """
@@ -91,7 +113,7 @@ def to_html(xml):
 
     converted_xml = str(ElementTree.tostring(root, encoding="utf-8"), "utf-8")
 
-    return css + converted_xml
+    return converted_xml
 
 # Sublime Text minihtml is a bit delicate. So here we remove tags that prevent
 # it working as expected.
@@ -109,16 +131,22 @@ def _sanitize(text):
     #
     # In English, this RE replaces all '<' characters with the string "&lt;"
     # when they appear between the strings "![CDATA[" and "]]>".
-    text = re.sub(r'<(?=(?:(?!(?:!\[CDATA\[|]]>)).)*?\]\]>)', '&lt;', text)
+    text = re.sub(r'<(?=(?:(?!(?:!\[CDATA\[|]]>)).)*?]]>)', '&lt;', text)
 
     text = text.replace("<![CDATA[", "")
     text = text.replace("]]>", "")
     text = text.replace("<rawHTML>", "")
     text = text.replace("</rawHTML>", "")
-    text = text.replace("<Discussion>", "")
-    text = text.replace("</Discussion>", "")
     text = text.replace("<zCodeLineNumbered></zCodeLineNumbered>", "")
-    text = text.replace("..<", "..&lt;")
+
+    # This was causing problems in cases where lines contained "...do something..."
+    #text = text.replace("..<", "..&lt;")
+
+    # Since Sublime's minihtml doesn't support preformatted text, we fake spaces
+    # and tabs by using a NO-BREAK SPACE character (Unicode: U+00A0).
+    text = re.sub(r'\t(?=(?:(?!(?:zCodeLineNumbered>|</zCodeLineNumbered>)).)*?</zCodeLineNumbered>)', u'\xA0\xA0\xA0\xA0', text)
+    text = re.sub(r' (?=(?:(?!(?:zCodeLineNumbered>|</zCodeLineNumbered>)).)*?</zCodeLineNumbered>)', u'\xA0', text)
+
     return text
 
 # The output we get isn't always the best looking, so this function does some
@@ -126,4 +154,5 @@ def _sanitize(text):
 def _tweaks(text):
     text = text.replace("<Direction isExplicit=\"0\">in</Direction>", ": ")
     text = text.replace("<Parameters>", "Parameters:<Parameters>")
+
     return text

--- a/src/sourcekit_xml_to_html.py
+++ b/src/sourcekit_xml_to_html.py
@@ -2,6 +2,7 @@
 # https://github.com/johncsnyder/SwiftKitten/blob/13c32401f16f0e6abd6deb180a9f96c590c27c6a/SwiftKitten.py#L650
 # so special thanks to John Snyder for starting this
 
+import re
 import xml.etree
 from xml.etree import ElementTree
 
@@ -95,6 +96,21 @@ def to_html(xml):
 # Sublime Text minihtml is a bit delicate. So here we remove tags that prevent
 # it working as expected.
 def _sanitize(text):
+    # Sanitize the contents of CDATA elements. We do this before removing the
+    # CDATA tags.
+    #
+    # Example:
+    #
+    #     <![CDATA[        bytes: count * MemoryLayout<Point>.stride,]]>
+    #
+    # ...becomes...
+    #
+    #     <![CDATA[        bytes: count * MemoryLayout&lt;Point>.stride,]]>
+    #
+    # In English, this RE replaces all '<' characters with the string "&lt;"
+    # when they appear between the strings "![CDATA[" and "]]>".
+    text = re.sub(r'<(?=(?:(?!(?:!\[CDATA\[|]]>)).)*?\]\]>)', '&lt;', text)
+
     text = text.replace("<![CDATA[", "")
     text = text.replace("]]>", "")
     text = text.replace("<rawHTML>", "")

--- a/src/subl_source_kitten.py
+++ b/src/subl_source_kitten.py
@@ -60,8 +60,14 @@ def popup(offset, file, project_directory, text):
     type_text = _popup_section_from_dict("Type", "key.typename", output)
     group_text = _popup_section_from_dict("Group", "key.groupname", output)
 
-    full_decl = _popup_section_from_dict("Declaration", "key.doc.full_as_xml", output, True)
+    full_decl = _popup_section_from_dict("Declaration", "key.doc.full_as_xml", output, True, r'.*?(<Declaration[^>]*?>.*?</Declaration>).*?', r'<CommentParts>.*?</CommentParts>')
     short_decl = _popup_section_from_dict("Declaration", "key.annotated_decl", output, True)
+
+    # Generate html for the <Abstract> section of the xml
+    abstract = _popup_section_from_dict("Abstract", "key.doc.full_as_xml", output, True, r'.*?(<Abstract[^>]*?>.*?</Abstract>).*?')
+
+    # Generate html for the <Discussion> section of the xml
+    discussion = _popup_section_from_dict("Discussion", "key.doc.full_as_xml", output, True, r'.*?(<Discussion[^>]*?>.*?</Discussion>).*?')
 
     source_loc_text = _source_location_popup_section(file, project_directory, output)
 
@@ -69,9 +75,14 @@ def popup(offset, file, project_directory, text):
     if len(short_decl) > len(full_decl):
         declaration_text = short_decl
 
-    popup_text = name_text + type_text + source_loc_text + declaration_text
+    popup_text = name_text + type_text + source_loc_text + declaration_text + abstract + discussion
 
-    return popup_text
+    # If we don't have any content, let the user know we're here and working but there wasn't any info
+    if popup_text == "":
+        popup_text = "No information found"
+
+    # Return the content prefixed by the CSS
+    return sourcekit_xml_to_html.css + popup_text
 
 def source_location_link(offset, file, project_directory, text):
     dictionary = source_kitten.cursor_info(offset, file, project_directory, text)
@@ -103,13 +114,28 @@ def _source_location_paths(file, project_directory, dictionary):
     href = absolute_path_with_offset + "-" + str(length)
     return [href, relative_path_with_offset]
 
-def _popup_section_from_dict(title, key, dictionary, xml=None):
+# If tag_filter is set, then it is used in a regex match, where the first match
+# is used as the section of XML to convert to HTML.
+#
+# If wipe_filter is set, then it is used as a regex replace with a blank string. This
+# Allows for specific tags to be filtered, but to remove contents within those tags
+# as needed. This operation is performed after tag_filter.
+def _popup_section_from_dict(title, key, dictionary, xml=None, tag_filter=None, wipe_filter=None):
     value = _value_or_empty_string(key, dictionary)
 
     if value == "":
         return ""
 
     if xml == True:
+        if tag_filter != None:
+            m = re.match(tag_filter, value)
+            value = ""
+            if m != None:
+                value = m.group(1)
+        if wipe_filter != None:
+            value = re.sub(wipe_filter, "", value)
+        if value == "":
+            return value
         value = sourcekit_xml_to_html.to_html(value)
     else:
         value = "" + cgi.escape(value) + ""

--- a/subl.py
+++ b/subl.py
@@ -77,6 +77,22 @@ class SourceKittenSublJumpToDefinitionCommand(sublime_plugin.TextCommand):
         instance.on_navigate(href)
 
 def _project_directory(view):
+    # Get the setting 'stsa.project_root' and use that, if it exists. The value stored in
+    # this setting honors ST3's variable expansion (see sublime.expand_variables() for more
+    # information.)
+    #
+    # Generally, you would want to put this into the project settings. Here is an example
+    # that specifies the subdirectory 'code' under your Sublime project's root directory:
+    #
+    #     "settings":
+    #     {
+    #         "stsa.project_root": "${project_path:${folder}}/code"
+    #     }
+    dir = view.settings().get("stsa.project_root")
+    if dir != None and type(dir) is str:
+        return sublime.expand_variables(dir, view.window().extract_variables())
+
+    # Fall back to using the top-most directory open in Sublime
     if len(view.window().folders()) > 0:
         return view.window().folders()[0]
     return ""


### PR DESCRIPTION
NOTE: I was originally typing this up while testing it to make sure I wasn't forgetting anything and somehow fat-fingered the submit button before I intended to. In my testing, I found an issue with 742d386 that I need to resolve. So before accepting that one, please wait for one more PR. (This is embarrassing.)

First, great job on this!

When I loaded it up, the first thing it did was to throw an exception complaining about an ASCII code. It turns out there was a copyright symbol in one of the source files and that was tripping it up when trying to convert the ASCII for writing to a text file. So 08d213e converts it to utf-8 and writes that stream to a binary file. With that out of the way, I was able to see the awesomeness that is SubllimeTextSwiftAutocomplete.

The next issue I ran into came when hovering over `MemoryLayout<SomeClass>.size`. This one, too, caused an exception. It turns out that the tag parsing wasn't taking into account that CDATA blocks can have tags in them without escaping the leading '<'. So d392249 was created to locate CDATA blocks, escape the tags with &lt; and then rip out the CDATA head/tail.

Next was the root directory. I have a rather extensive directory tree for my project (with documents, large PSDs, a good number of video files, etc.) and the Swift code is in one subdirectory. So in 5639bc9, I added the ability to create a setting called 'stsa.project_root' to specify the root. I put mine in my project settings. If that setting is not present, it will revert to the original behavior.

And finally, no documentation showed up for me. After some investigation, it looked like it might work in some cases, but not in my case (not really sure why - maybe a tools version issue?) So I did some work to parse out the Abstract and Discussion bits separately in order to display them as real blocks and 742d386 was born. I'll admit this one is a bit hacky with some regex patterns being passed around. (I was trying to touch as little code as possible.)

The end result looks a little like this:

<img width="582" alt="screen shot 2018-02-14 at 5 55 11 pm" src="https://user-images.githubusercontent.com/7917889/36234382-576ce820-11b0-11e8-843d-f871427a78de.png">

Feel free to pick better colors on this one. In fact, I encourage you to.
